### PR TITLE
Strip out unused dependencies & upgrade packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ README.md
 
 # PDM
 .pdm.toml
+pdm.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,24 +6,18 @@ authors = [
     {name = "Rob Savoye", email = "rob.savoye@hotosm.org"},
 ]
 dependencies = [
-    "codetiming==1.3.2",
+    "codetiming==1.4.0",
     "epdb==0.15.1",
-    "GDAL==3.4.3",
     "geodex==0.1.2",
     "geojson==2.5.0",
-    "numpy==1.22.0",
     "OSMPythonTools==0.3.5",
-    "pandas==1.3.4",
     "progress==1.6",
-    "py-cpuinfo==8.0.0",
     "pymbtiles==0.5.0",
-    "pytest==7.0.1",
     "PyYAML==6.0",
-    "qrcode==7.3.1",
-    "requests==2.27.1",
+    "qrcode==7.4.2",
+    "requests==2.28.2",
     "segno==1.5.2",
-    "Shapely==1.7.1",
-    "xmltodict==0.12.0",
+    "xmltodict==0.13.0",
 ]
 requires-python = ">=3.9"
 readme = "README.md"
@@ -41,10 +35,15 @@ homepage = "https://github.com/hotosm/odkconvert"
 documentation = "https://github.com/hotosm/odkconvert"
 repository = "https://github.com/hotosm/odkconvert"
 
+[project.optional-dependencies]
 [tool.pdm]
 includes = ["odkconvert"]
 source-includes = ["tests", "LICENSE.md", "README.md"]
 version = {from = "odkconvert/__version__.py"}
+[tool.pdm.dev-dependencies]
+test = [
+    "pytest>=7.2.1",
+]
 
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,18 @@ authors = [
     {name = "Rob Savoye", email = "rob.savoye@hotosm.org"},
 ]
 dependencies = [
-    "codetiming==1.4.0",
-    "epdb==0.15.1",
-    "geodex==0.1.2",
-    "geojson==2.5.0",
-    "OSMPythonTools==0.3.5",
-    "progress==1.6",
-    "pymbtiles==0.5.0",
-    "PyYAML==6.0",
-    "qrcode==7.4.2",
-    "requests==2.28.2",
-    "segno==1.5.2",
-    "xmltodict==0.13.0",
+    "codetiming>=1.4.0",
+    "epdb>=0.15.1",
+    "geodex>=0.1.2",
+    "geojson>=2.5.0",
+    "OSMPythonTools>=0.3.5",
+    "progress>=1.6",
+    "pymbtiles>=0.5.0",
+    "PyYAML>=6.0",
+    "qrcode>=7.4.2",
+    "requests>=2.28.2",
+    "segno>=1.5.2",
+    "xmltodict>=0.13.0",
 ]
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
- We have some conflicting dependency versions between fmtm and odkconvert (e.g. Shapely, which isn't used yet).
- I propose we strip out unused dependencies from the odkconvert package, until we need the functionality (GDAL is great, but removing it does reduce some future headaches with automated builds).
- I also upgraded a few packages on patch versions (no major semver).
- I moved pytest into dev-dependencies.